### PR TITLE
Install the numpy==1.23.5 dependency AFTER TTS

### DIFF
--- a/install_requirements.txt
+++ b/install_requirements.txt
@@ -3,6 +3,7 @@
 ;;; If there's no condition, always install.
 torch==2.0.1 torchvision torchaudio;--index-url https://download.pytorch.org/whl/cu117;windows
 torch==2.0.1 torchvision torchaudio;;not windows
+numpy==1.23.5
 transformers
 diffusers
 gradio

--- a/install_requirements.txt
+++ b/install_requirements.txt
@@ -3,7 +3,6 @@
 ;;; If there's no condition, always install.
 torch==2.0.1 torchvision torchaudio;--index-url https://download.pytorch.org/whl/cu117;windows
 torch==2.0.1 torchvision torchaudio;;not windows
-numpy==1.23.5
 transformers
 diffusers
 gradio

--- a/setup_tools/magicinstaller/requirements/__init__.py
+++ b/setup_tools/magicinstaller/requirements/__init__.py
@@ -16,7 +16,7 @@ requirements = [
     Packaging(),  # Allows for version checks
 
     # SimpleRequirementInit('numpy', CompareAction.EQ, '1.23.5'),
-    NoColabRequirement('numpy', CompareAction.EQ, '1.23.5'),  # Don't install this one when in google colab
+    NoColabRequirement('numpy'),  # Don't install this one when in google colab
 
     Torch(),
 

--- a/setup_tools/magicinstaller/requirements/__init__.py
+++ b/setup_tools/magicinstaller/requirements/__init__.py
@@ -15,8 +15,10 @@ from setup_tools.magicinstaller.requirement import SimpleRequirementInit, Compar
 requirements = [
     Packaging(),  # Allows for version checks
 
+    TTS(),
+
     # SimpleRequirementInit('numpy', CompareAction.EQ, '1.23.5'),
-    NoColabRequirement('numpy'),  # Don't install this one when in google colab
+    NoColabRequirement('numpy', CompareAction.EQ, '1.23.5'),  # Don't install this one when in google colab
 
     Torch(),
 
@@ -41,8 +43,6 @@ requirements = [
     NoiseReduce(),
     LibRosa(),
     Demucs(),
-
-    TTS(),
 
     PyTube(),
 


### PR DESCRIPTION
Related to this error: https://github.com/gitmylo/audio-webui/issues/49

The reason this is happening is because the magicinstaller has hardcoded numpy as 1.23.5, but if you look at TTS, it uses lower versions depending on python version: https://github.com/coqui-ai/TTS/blob/dev/requirements.txt#L2-L3

```
numpy==1.22.0;python_version<="3.10"
numpy==1.24.3;python_version>"3.10"
```

Initially I tried to tackle this problem by just getting rid of the 1.23.5, and it did solve the installation problem (I could launch the web UI).

However this resulted in the installed torch not recognizing numpy and kept throwing an "Numpy is not available" error when I actually tried to generate audio inside the web ui.

So the solution was to keep the 1.23.5, but move the TTS install step to the beginning, so the numpy 1.23.5 would override the requirements specified in the TTS package (as mentioned above)