### PR TITLE
Use /usr/bin/env for getting the correct path to bash

### DIFF
--- a/setup_tools/commands.py
+++ b/setup_tools/commands.py
@@ -17,7 +17,7 @@ def run_command(command: list[tuple[str, str]] | str, args='', show_output=True)
     
     # Ensure bin/bash shell
     if not is_windows():
-        commandstr = f'/bin/bash -c "{commandstr}"'
+        commandstr = f'/usr/bin/env bash -c "{commandstr}"'
         
     system(commandstr)
 


### PR DESCRIPTION
Thanks for the work on this repo, love audio-webui!

This PR uses /usr/bin/env for getting the correct path to bash

This issue prevents the software from running on Nix (or anywhere else without /bin/bash)