### PR TITLE
Update download.py (remove deprecated use of `ModelFilter`)

### DIFF
--- a/webui/modules/download.py
+++ b/webui/modules/download.py
@@ -38,7 +38,7 @@ def fill_models(model_type: str):
     if model_type == 'rvc':
         return get_rvc_models()
     return [model.id for model in
-            huggingface_hub.list_models(filter=huggingface_hub.ModelFilter(task=model_type), sort='downloads')]
+            huggingface_hub.list_models(task=model_type, sort='downloads')]
 
 
 def get_file_name(repo_id: str):


### PR DESCRIPTION
This PR remove deprecated use of `ModelFilter`. Arguments can now be passed to `list_models` directly. See https://github.com/huggingface/huggingface_hub/issues/2028 for more details.